### PR TITLE
Refactor: Version Control for Provider Configuration

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,8 @@
+/* 
+  Refactored by AI recommendation: Version Control for Provider Configuration
+  Original code:
+  provider "aws" { region = "us-west-2" }
+  
+  Refactored code:
+*/
+provider "aws" { version = "~> 3.0" region = "us-west-2" }


### PR DESCRIPTION
This PR implements the recommended change:

The provider block should specify the required version to ensure stability and compatibility of the provider's features. Omitting version constraints can lead to unexpected changes affecting deployments.

Original code:
```
provider "aws" { region = "us-west-2" }
```

New code:
```
provider "aws" { version = "~> 3.0" region = "us-west-2" }
```